### PR TITLE
Use relative paths for `require` in tests

### DIFF
--- a/dimensions.gemspec
+++ b/dimensions.gemspec
@@ -13,5 +13,6 @@ spec = Gem::Specification.new do |s|
   s.summary      = "Pure Ruby dimension measurement for GIF, PNG, JPEG and TIFF images"
   s.description  = "A pure Ruby library for measuring the dimensions and rotation angles of GIF, PNG, JPEG and TIFF images."
   s.files        = Dir["README.md", "LICENSE", "lib/**/*.rb"]
+  s.test_files   = Dir["test/**/*"]
   s.require_path = "lib"
 end

--- a/dimensions.gemspec
+++ b/dimensions.gemspec
@@ -13,6 +13,5 @@ spec = Gem::Specification.new do |s|
   s.summary      = "Pure Ruby dimension measurement for GIF, PNG, JPEG and TIFF images"
   s.description  = "A pure Ruby library for measuring the dimensions and rotation angles of GIF, PNG, JPEG and TIFF images."
   s.files        = Dir["README.md", "LICENSE", "lib/**/*.rb"]
-  s.test_files   = Dir["test/**/*"]
   s.require_path = "lib"
 end

--- a/test/test_dimensions.rb
+++ b/test/test_dimensions.rb
@@ -1,4 +1,4 @@
-require 'dimensions/test_case'
+require_relative 'dimensions/test_case'
 
 class TestDimensions < Dimensions::TestCase
   def test_animated_gif_dimensions

--- a/test/test_exif_scanner.rb
+++ b/test/test_exif_scanner.rb
@@ -1,4 +1,4 @@
-require 'dimensions/test_case'
+require_relative 'dimensions/test_case'
 
 class TestExifScanner < Dimensions::TestCase
   def test_scanning_exif_with_top_left_orientation

--- a/test/test_io.rb
+++ b/test/test_io.rb
@@ -1,4 +1,4 @@
-require 'dimensions/test_case'
+require_relative 'dimensions/test_case'
 
 class TestIO < Dimensions::TestCase
   def test_extends_io

--- a/test/test_jpeg_scanner.rb
+++ b/test/test_jpeg_scanner.rb
@@ -1,4 +1,4 @@
-require 'dimensions/test_case'
+require_relative 'dimensions/test_case'
 
 class TestJpegScanner < Dimensions::TestCase
   def test_scanning_jpeg

--- a/test/test_reader.rb
+++ b/test/test_reader.rb
@@ -1,4 +1,4 @@
-require 'dimensions/test_case'
+require_relative 'dimensions/test_case'
 
 class TestReader < Dimensions::TestCase
   def test_identifying_gif_file

--- a/test/test_tiff_scanner.rb
+++ b/test/test_tiff_scanner.rb
@@ -1,4 +1,4 @@
-require 'dimensions/test_case'
+require_relative 'dimensions/test_case'
 
 class TestTiffScanner < Dimensions::TestCase
   def test_scanning_tiff_with_short_values


### PR DESCRIPTION
With out this, we couldn’t run the tests without mucking with the `$LOAD_PATH`.
